### PR TITLE
Added customizable player names

### DIFF
--- a/blockenv.config.json
+++ b/blockenv.config.json
@@ -4,7 +4,8 @@
         "client": {
             "name": "Client Environment",
             "type": "client",
-            "path": "client"
+            "path": "client",
+            "playerName": "Sftotwar gpe"
         },
         "client2": {
             "name": "Client Environment 2",

--- a/dist/commands/launch/client/index.js
+++ b/dist/commands/launch/client/index.js
@@ -30,11 +30,12 @@ function getClasspathSeperator(osName) {
 }
 
 module.exports.launchClient = async function(cliVersion, options, config) {
-    const { profile } = options;
+    const { profile, environment } = options;
     const installDir = determineInstallPath(options, config);
     const versionsDir = join(installDir, "versions");
     const libDir = join(installDir, "libraries");
     const assetsDir = join(installDir, "assets");
+    const playerName = environment.playerName;
     const osName = detectOS();
     const arch = detectArch();
     const classpathSeparator = getClasspathSeperator(osName);
@@ -46,7 +47,7 @@ module.exports.launchClient = async function(cliVersion, options, config) {
 
     const subsitute = (str) => subsitutePlaceholders(str, {
         version: cliVersion, classpath, loaderVersion: version, libDir, classpathSeparator,
-        assetsDir, assetIndex, versionType: versionJSON.type, gameDir: installDir
+        assetsDir, assetIndex, playerName, versionType: versionJSON.type, gameDir: installDir
     });
     const jvmArgs = versionJSON.arguments.jvm.map(arg => subsitute(arg));
     const gameArgs = versionJSON.arguments.game.map(arg => subsitute(arg));

--- a/dist/commands/launch/client/placeholder.js
+++ b/dist/commands/launch/client/placeholder.js
@@ -15,6 +15,20 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
+const { createHash } = require("crypto");
+
+function generateUUID(playerName) {
+    const data = "OfflinePlayer:" + playerName;
+    const hash = createHash("md5").update(data, "utf8").digest();
+    hash[6] &= 0x0f; hash[6] |= 0x30; 
+    hash[8] &= 0x3f; hash[8] |= 0x80;
+    return [...hash].map((b, i) =>
+    (b & 0xff).toString(16).padStart(2, "0") +
+    ([3, 5, 7, 9].includes(i) ? "-" : "")
+    ).join("").slice(0, 36);
+}
+
 module.exports.subsitutePlaceholders = function(text,
     {
         version, classpath, loaderVersion, libDir, classpathSeparator,
@@ -22,6 +36,9 @@ module.exports.subsitutePlaceholders = function(text,
         authUUID = "00000000-0000-0000-0000-000000000000", accessToken = "none",
         userType = "legacy", versionType, gameDir
     }) {
+
+    const UUID = playerName == "OfflinePlayer" ? authUUID : generateUUID(playerName);
+
     return text
         .replaceAll("${launcher_name}", "BlockEnv")
         .replaceAll("${launcher_version}", version)
@@ -33,7 +50,7 @@ module.exports.subsitutePlaceholders = function(text,
         .replaceAll("${assets_root}", assetsDir)
         .replaceAll("${assets_index_name}", assetIndex)
         .replaceAll("${auth_player_name}", playerName)
-        .replaceAll("${auth_uuid}", authUUID)
+        .replaceAll("${auth_uuid}", UUID)
         .replaceAll("${auth_access_token}", accessToken)
         .replaceAll("${user_type}", userType)
         .replaceAll("${version_type}", versionType)

--- a/dist/structures/Environment.js
+++ b/dist/structures/Environment.js
@@ -35,6 +35,10 @@ module.exports.Environment = class Environment {
         return this.#data.path;
     }
 
+    get playerName(){
+        return this.#data.playerName;
+    }
+
     #validateData(data = this.#data) {
         if (!data || typeof data !== "object" || Array.isArray(data)) {
             throw new Error("Environment data must be an object.");
@@ -47,6 +51,28 @@ module.exports.Environment = class Environment {
         }
         if (!data.path || typeof data.path !== "string") {
             throw new Error("Environment path must be a string.");
+        }
+        this.#validatePlayerName();
+    }
+
+    #validatePlayerName(data = this.#data) {
+        if (!data.playerName) {
+            return;
+        }
+        if(data.type == "server"){
+            throw new Error("Environment playerName can not be set in a server type environment");
+        }
+        if(typeof data.playerName !== "string"){
+            throw new Error("Environment playerName must be a string.");
+        }
+        if (data.playerName.length === 0) {
+            throw new Error("Environment playerName cannot be empty.");
+        }
+        if (!/^[A-Za-z0-9_]+$/.test(data.playerName)) {
+            throw new Error("Environment playerName can only contain letters, numbers, and underscores.");
+        }
+        if (data.playerName.length > 16) {
+            throw new Error("Environment playerName is too long");
         }
     }
 }


### PR DESCRIPTION
Using this environment in the config
	    "client": {
            "name": "Client Environment",
            "type": "client",
            "path": "client",
            "playerName": "developer"
        },
  
  The UUID should always be da076fe3-e7c7-31a6-930d-086c78a73889
  and the playerName developer