### PR TITLE
feat(setup)!: change order of setup

### DIFF
--- a/dist/commands/setup/client/profile.js
+++ b/dist/commands/setup/client/profile.js
@@ -16,11 +16,15 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 const { existsSync } = require("node:fs");
-const { writeFile } = require("node:fs/promises");
+const { writeFile, mkdir } = require("node:fs/promises");
 const { join } = require("node:path");
 
 module.exports.generateLauncherProfiles = async function({ installDir }) {
     const profileFile = join(installDir, "launcher_profiles.json");
+
+	if (!existsSync(installDir)) {
+		await mkdir(installDir, { recursive: true });
+	}
 
     if (!existsSync(profileFile)) {
         console.log("Generating launcher profiles...");

--- a/dist/commands/setup/index.js
+++ b/dist/commands/setup/index.js
@@ -16,7 +16,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 const { parseLoader, parseEnvName } = require("../../parsers");
-const { Option, InvalidArgumentError} = require("commander");
+const { InvalidArgumentError} = require("commander");
+const Option = require("../../lib/Option");
 
 /**
  * @param {import("../../lib").Program} program
@@ -27,13 +28,21 @@ module.exports.loadCommands = function(program) {
         .description("Setup the testing environment")
         .addOption(new Option("-s, --side <side>", "Whether to setup the server or client").choices(["client", "server"]))
         .addOption(new Option("-e, --environment <environment>", "Which environment to setup").conflicts("side").argParser(parseEnvName.bind(null, program.config())))
-        .option("-m, --minecraft-version <version>", "Specify the Minecraft version to use")
 		.addOption(new Option("-l, --loader <loader>", "Specify the modloader to use (currently only 'neoforge' is supported)").argParser(parseLoader))
 		.addOption(new Option("--loader-version <version>", "Specify the modloader version to use"))
+		.addOption(new Option("-m, --minecraft-version <version>", "Specify the Minecraft version to use").deprecate())
+		// TODO: remove this flag in version 2.0.0, keep it for now to maintain compatibility with older setups
+		.addOption(new Option("--new-setup-order", "Enable the new order of setup, which first runs the installer and then downloads the libraries and assets").conflicts("minecraftVersion").default(false))
 		.hook("preAction", (thisCommand) => {
-			const { environment, loader, loaderVersion } = thisCommand.opts();
+			const { environment, loader, loaderVersion, newSetupOrder, minecraftVersion } = thisCommand.opts();
 			if (environment && !environment.loader && !(loader && loaderVersion)) {
 				throw new InvalidArgumentError("No loader specified for environment. Please specify a loader and its version.");
+			}
+			if (!newSetupOrder) {
+				console.warn("Warning: The legacy setup order is deprecated and will be removed in v2.0.0. To switch to the new setup process, enable the --new-setup-order option.");
+			}
+			if (!newSetupOrder && !minecraftVersion) {
+				throw new InvalidArgumentError("No Minecraft version specified. Please specify a Minecraft version using the '--minecraft-version' option.");
 			}
 		})
 		.action(async (options) => {


### PR DESCRIPTION
BREAKING CHANGE (currently behind flag --new-setup-order, default in v2.0.0):

This changes the order of operations in the `setup` command.  
Previously, the client installer first downloaded Minecraft libraries and assets, then ran the mod loader installer.  
With the new behavior, the mod loader installer runs **first**, followed by the Minecraft libraries and assets download.

Enable this behavior early by using `--new-setup-order`.